### PR TITLE
Add 'SubNet' class and modify related files

### DIFF
--- a/matlab/+dagnn/@DagNN/DagNN.m
+++ b/matlab/+dagnn/@DagNN/DagNN.m
@@ -1,377 +1,413 @@
 classdef DagNN < handle
-%DagNN Directed acyclic graph neural network
-%   DagNN is a CNN wrapper alternative to SimpleNN. It is object
-%   oriented and allows constructing networks with a directed acyclic
-%   graph (DAG) topology. It is therefore far more flexible, although
-%   a little more complex and slightly slower for small CNNs.
-%
-%   A DAG object contains the following data members:
-%
-%   - `layers`: The network layers.
-%   - `vars`: The network variables.
-%   - `params`: The network parameters.
-%   - `meta`: Additional information relative to the CNN (e.g. input
-%     image format specification).
-%
-%   There are additional transient data members:
-%
-%   `mode`:: `normal`
-%      This flag can either be `normal` or `test`. In the latter case,
-%      certain blocks switch to a test mode suitable for validation or
-%      evaluation as opposed to training. For instance, dropout
-%      becomes a pass-through block in `test` mode.
-%
-%   `accumulateParamDers`:: `false`
-%      If this flag is set to `true`, then the derivatives of the
-%      network parameters are accumulated rather than rewritten the
-%      next time the derivatives are computed.
-%
-%   `conserveMemory`:: `true`
-%      If this flag is set to `true`, the DagNN will discard
-%      intermediate variable values as soon as they are not needed
-%      anymore in the calculations. This is particularly important to
-%      save memory on GPUs.
-%
-%   `device`:: `cpu`
-%      This flag tells whether the DagNN resides in CPU or GPU
-%      memory. Use the `DagNN.move()` function to move the DagNN
-%      between devices.
-
-% Copyright (C) 2015 Karel Lenc and Andrea Vedaldi.
-% All rights reserved.
-%
-% This file is part of the VLFeat library and is made available under
-% the terms of the BSD license (see the COPYING file).
-
-  properties
-    layers
-    vars
-    params
-    meta
-  end
-
-  properties (Transient)
-    mode = 'normal'
-    accumulateParamDers = false
-    conserveMemory = true
-  end
-
-  properties (Transient, SetAccess = private, GetAccess = public)
-    device = 'cpu' ;
-  end
-
-  properties (Transient, Access = {?dagnn.DagNN, ?dagnn.Layer}, Hidden = true)
-    numPendingVarRefs
-    numPendingParamRefs
-    computingDerivative = false
-    executionOrder
-  end
-
-  properties (Transient, Access = private, Hidden = true)
-    modifed = false
-    varNames = struct()
-    paramNames = struct()
-    layerNames = struct()
-    layerIndexes = {}
-  end
-
-  methods
-    function obj = DagNN()
-    %DAGNN  Initialize an empty DaG
-    %   OBJ = DAGNN() initializes an empty DaG.
+    %DagNN Directed acyclic graph neural network
+    %   DagNN is a CNN wrapper alternative to SimpleNN. It is object
+    %   oriented and allows constructing networks with a directed acyclic
+    %   graph (DAG) topology. It is therefore far more flexible, although
+    %   a little more complex and slightly slower for small CNNs.
     %
-    %   See Also addLayer(), loadobj(), saveobj().
-      obj.vars = struct(...
-        'name', {}, ...
-        'value', {}, ...
-        'der', {}, ...
-        'fanin', {}, ...
-        'fanout', {}, ...
-        'precious', {}) ;
-      obj.params = struct(...
-        'name', {}, ...
-        'value', {}, ...
-        'der', {}, ...
-        'fanout', {}, ...
-        'trainMethod', {}, ...
-        'learningRate', {}, ...
-        'weightDecay', {}) ;
-      obj.layers = struct(...
-        'name', {}, ...
-        'inputs', {}, ...
-        'outputs', {}, ...
-        'params', {}, ...
-        'inputIndexes', {}, ...
-        'outputIndexes', {}, ...
-        'paramIndexes', {}, ...
-        'forwardTime', {[]}, ...
-        'backwardTime', {[]}, ...
-        'block', {}) ;
-    end
-
-    function set.mode(obj, mode)
-      switch lower(mode)
-        case {'normal', 'train'}
-          obj.mode = 'normal' ;
-        case {'test'}
-          obj.mode = 'test' ;
-      end
-    end
-
-    % Manage the DagNN
-    reset(obj)
-    move(obj, direction)
-    s = saveobj(obj)
-
-    % Manipualte the DagNN
-    addLayer(obj, name, block, inputs, outputs, params)
-    removeLayer(obj, name)
-    setLayerInputs(obj, leyer, inputs)
-    setLayerOutput(obj, layer, outputs)
-    setLayerParams(obj, layer, params)
-    renameVar(obj, oldName, newName, varargin)
-    rebuild(obj)
-
-    % Process data with the DagNN
-    initParams(obj)
-    eval(obj, inputs, derOutputs)
-
-    % Get information about the DagNN
-    varSizes = getVarSizes(obj, inputSizes)
-
-    % ---------------------------------------------------------------------
-    %                                                           Access data
-    % ---------------------------------------------------------------------
-
-    function inputs = getInputs(obj)
-    %GETINPUTS Get the names of the input variables
-    %   INPUTS = GETINPUTS(obj) returns a cell array containing the name
-    %   of the input variables of the DaG obj, i.e. the sources of the
-    %   DaG (excluding the network parameters, which can also be
-    %   considered sources).
-      v = find([obj.vars.fanin]==0) ;
-      inputs = {obj.vars(v).name} ;
-    end
-
-    function outputs = getOutputs(obj)
-    %GETOUTPUTS Get the names of the output variables
-    %    OUTPUT = GETOUTPUTS(obj) returns a cell array containing the name
-    %    of the output variables of the DaG obj, i.e. the sinks of the
-    %    DaG.
-      v = find([obj.vars.fanout]==0) ;
-      outputs = {obj.vars(v).name} ;
-    end
-
-    function l = getLayerIndex(obj, name)
-    %GETLAYERINDEX Get the index of a layer
-    %   INDEX = GETLAYERINDEX(obj, NAME) returns the index of the layer
-    %   NAME. NAME can also be a cell array of strings. If no layer
-    %   with such a name is found, the value NaN is returned for the
-    %   index.
+    %   A DAG object contains the following data members:
     %
-    %   Layers can then be accessed as the `obj.layers(INDEX)`
-    %   property of the DaG.
+    %   - `layers`: The network layers.
+    %   - `vars`: The network variables.
+    %   - `params`: The network parameters.
+    %   - `meta`: Additional information relative to the CNN (e.g. input
+    %     image format specification).
+    %   - `subnets`: subnets in the net.
     %
-    %   Indexes are stable unless the DaG is modified (e.g. by adding
-    %   or removing layers); hence they can be cached for faster
-    %   variable access.
     %
-    %   See Also getParamIndex(), getVarIndex().
-      if iscell(name)
-        l = zeros(1, numel(name)) ;
-        for k = 1:numel(name)
-          l(k) = obj.getLayerIndex(name{k}) ;
+    %   There are additional transient data members:
+    %
+    %   `mode`:: `normal`
+    %      This flag can either be `normal` or `test`. In the latter case,
+    %      certain blocks switch to a test mode suitable for validation or
+    %      evaluation as opposed to training. For instance, dropout
+    %      becomes a pass-through block in `test` mode.
+    %
+    %   `accumulateParamDers`:: `false`
+    %      If this flag is set to `true`, then the derivatives of the
+    %      network parameters are accumulated rather than rewritten the
+    %      next time the derivatives are computed.
+    %
+    %   `conserveMemory`:: `true`
+    %      If this flag is set to `true`, the DagNN will discard
+    %      intermediate variable values as soon as they are not needed
+    %      anymore in the calculations. This is particularly important to
+    %      save memory on GPUs.
+    %
+    %   `device`:: `cpu`
+    %      This flag tells whether the DagNN resides in CPU or GPU
+    %      memory. Use the `DagNN.move()` function to move the DagNN
+    %      between devices.
+    
+    % Copyright (C) 2015 Karel Lenc and Andrea Vedaldi.
+    % All rights reserved.
+    %
+    % This file is part of the VLFeat library and is made available under
+    % the terms of the BSD license (see the COPYING file).
+    
+    properties
+        layers
+        vars
+        params
+        SubNets
+        meta
+    end
+    
+    properties (Transient)
+        mode = 'normal'
+        accumulateParamDers = false
+        conserveMemory = true
+    end
+    
+    properties (Transient, SetAccess = private, GetAccess = public)
+        device = 'cpu' ;
+    end
+    
+    properties (Transient, Access = {?dagnn.DagNN, ?dagnn.Layer}, Hidden = true)
+        numPendingVarRefs
+        numPendingParamRefs
+        computingDerivative = false
+        executionOrder
+    end
+    
+    properties (Transient, Access = private, Hidden = true)
+        modifed = false
+        varNames = struct()
+        paramNames = struct()
+        layerNames = struct()
+        SubNetNames=struct();
+        layerIndexes = {}
+    end
+    
+    methods
+        function obj = DagNN()
+            %DAGNN  Initialize an empty DaG
+            %   OBJ = DAGNN() initializes an empty DaG.
+            %
+            %   See Also addLayer(), loadobj(), saveobj().
+            obj.vars = struct(...
+                'name', {}, ...
+                'value', {}, ...
+                'der', {}, ...
+                'fanin', {}, ...
+                'fanout', {}, ...
+                'precious', {}) ;
+            obj.params = struct(...
+                'name', {}, ...
+                'value', {}, ...
+                'der', {}, ...
+                'fanout', {}, ...
+                'trainMethod', {}, ...
+                'learningRate', {}, ...
+                'weightDecay', {}) ;
+            obj.layers = struct(...
+                'name', {}, ...
+                'inputs', {}, ...
+                'outputs', {}, ...
+                'params', {}, ...
+                'inputIndexes', {}, ...
+                'outputIndexes', {}, ...
+                'paramIndexes', {}, ...
+                'forwardTime', {[]}, ...
+                'backwardTime', {[]}, ...
+                'block', {}) ;
+            obj.SubNets={};
         end
-      else
-        if isfield(obj.layerNames, name)
-          l = obj.layerNames.(name) ;
-        else
-          l = NaN ;
+        
+        function set_mode(obj, mode)
+            switch lower(mode)
+                case {'normal', 'train'}
+                    obj.mode = 'normal' ;
+                case {'test'}
+                    obj.mode = 'test' ;
+            end
         end
-      end
+        
+        % Manage the DagNN
+        reset(obj)
+        move(obj, direction)
+        s = saveobj(obj)
+        
+        % Manipualte the DagNN
+        addLayer(obj, name, block, inputs, outputs, params)
+        removeLayer(obj, name)
+        setLayerInputs(obj, leyer, inputs)
+        setLayerOutput(obj, layer, outputs)
+        setLayerParams(obj, layer, params)
+        renameVar(obj, oldName, newName, varargin)
+        rebuild(obj)
+        
+        % Process data with the DagNN
+        setParamsValue(obj,params,value)
+        initParams(obj)
+        eval(obj, inputs, derOutputs)
+        
+        % Get information about the DagNN
+        varSizes = getVarSizes(obj, inputSizes)
+        
+        % ---------------------------------------------------------------------
+        %                                                           Access data
+        % ---------------------------------------------------------------------
+        
+        function inputs = getInputs(obj)
+            %GETINPUTS Get the names of the input variables
+            %   INPUTS = GETINPUTS(obj) returns a cell array containing the name
+            %   of the input variables of the DaG obj, i.e. the sources of the
+            %   DaG (excluding the network parameters, which can also be
+            %   considered sources).
+            v = find([obj.vars.fanin]==0) ;
+            inputs = {obj.vars(v).name} ;
+        end
+        
+        function outputs = getOutputs(obj)
+            %GETOUTPUTS Get the names of the output variables
+            %    OUTPUT = GETOUTPUTS(obj) returns a cell array containing the name
+            %    of the output variables of the DaG obj, i.e. the sinks of the
+            %    DaG.
+            v = find([obj.vars.fanout]==0) ;
+            outputs = {obj.vars(v).name} ;
+        end
+        
+        function l = getLayerIndex(obj, name)
+            %GETLAYERINDEX Get the index of a layer
+            %   INDEX = GETLAYERINDEX(obj, NAME) returns the index of the layer
+            %   NAME. NAME can also be a cell array of strings. If no layer
+            %   with such a name is found, the value NaN is returned for the
+            %   index.
+            %
+            %   Layers can then be accessed as the `obj.layers(INDEX)`
+            %   property of the DaG.
+            %
+            %   Indexes are stable unless the DaG is modified (e.g. by adding
+            %   or removing layers); hence they can be cached for faster
+            %   variable access.
+            %
+            %   See Also getParamIndex(), getVarIndex().
+            if iscell(name)
+                l = zeros(1, numel(name)) ;
+                for k = 1:numel(name)
+                    l(k) = obj.getLayerIndex(name{k}) ;
+                end
+            else
+                if isfield(obj.layerNames, name)
+                    l = obj.layerNames.(name) ;
+                else
+                    l = NaN ;
+                end
+            end
+        end
+        
+        
+        function s=getSubNetIndex(obj,name)
+            if iscell(name)
+                s = zeros(1, numel(name)) ;
+                for k = 1:numel(name)
+                    s(k) = obj.getSubNetIndex(name{k}) ;
+                end
+            else
+                if isfield(obj.SubNetNames, name)
+                    s = obj.SubNetNames.(name) ;
+                else
+                    s = NaN ;
+                end
+            end
+        end
+        
+        
+        function v = getVarIndex(obj, name)
+            %GETVARINDEX Get the index of a variable
+            %   INDEX = GETVARINDEX(obj, NAME) obtains the index of the variable
+            %   with the specified NAME. NAME can also be a cell array of
+            %   strings. If no variable with such a name is found, the value
+            %   NaN is returned for the index.
+            %
+            %   Variables can then be accessed as the `obj.vars(INDEX)`
+            %   property of the DaG.
+            %
+            %   Indexes are stable unless the DaG is modified (e.g. by adding
+            %   or removing layers); hence they can be cached for faster
+            %   variable access.
+            %
+            %   See Also getParamIndex(), getLayerIndex().
+            if iscell(name)
+                v = zeros(1, numel(name)) ;
+                for k = 1:numel(name)
+                    v(k) = obj.getVarIndex(name{k}) ;
+                end
+            else
+                if isfield(obj.varNames, name)
+                    v = obj.varNames.(name) ;
+                else
+                    v = NaN ;
+                end
+            end
+        end
+        
+        function p = getParamIndex(obj, name)
+            %GETPARAMINDEX Get the index of a parameter
+            %   INDEX = GETPARAMINDEX(obj, NAME) obtains the index of the
+            %   parameter with the specified NAME. NAME can also be a cell
+            %   array of strings. If no parameter with such a name is found,
+            %   the value NaN is returned for the index.
+            %
+            %   Parameters can then be accessed as the `obj.params(INDEX)`
+            %   property of the DaG.
+            %
+            %   Indexes are stable unless the DaG is modified (e.g. by adding
+            %   or removing layers); hence they can be cached for faster
+            %   parameter access.
+            %
+            %   See Also getVarIndex(), getLayerIndex().
+            if iscell(name)
+                p = zeros(1, numel(name)) ;
+                for k = 1:numel(name)
+                    p(k) = obj.getParamIndex(name{k}) ;
+                end
+            else
+                if isfield(obj.paramNames, name)
+                    p = obj.paramNames.(name) ;
+                else
+                    p = NaN ;
+                end
+            end
+        end
+        
+        function layer = getLayer(obj, layerName)
+            %GETLAYER Get a copy of a layer definition
+            %   LAYER = GETLAYER(obj, NAME) returns a copy of the layer definition
+            %   structure with the specified NAME. NAME can also be a cell array
+            %   of strings or an array of indexes. If no parameter with a
+            %   specified name or index exists, an error is thrown.
+            %
+            %   See Also getLayerIndex().
+            if isnumeric(layerName)
+                idxs = layerName;
+                if any(idxs > numel(obj.layers) || idxs < 0)
+                    error('Invalid layer indexes.');
+                end
+            else
+                assert(ischar(layerName), 'Layer name must be string or number.');
+                idxs = obj.getLayerIndex(layerName);
+                if any(isnan(idxs))
+                    error('Invalid layer name `[%s]`', ...
+                        strjoin(layerName(isnan(idxs)), ', '));
+                end
+            end
+            layer = obj.layers(idxs);
+        end
+        
+        function var = getVar(obj, varName)
+            %GETVAR Get a copy of a layer definition
+            %   VAR = GETVAR(obj, NAME) returns a copy of the network variable
+            %   with the specified NAME. NAME can also be a cell array
+            %   of strings or an array of indexes. If no variable with a
+            %   specified name or index exists, an error is thrown.
+            %
+            %   See Also getVarIndex().
+            if isnumeric(varName)
+                idxs = varName;
+                if any(idxs > numel(obj.vars) || idxs < 0)
+                    error('Invalid var indexes.');
+                end
+            else
+                assert(ischar(varName), 'Variable name must be string or number.');
+                idxs = obj.getVarIndex(varName);
+                if any(isnan(idxs))
+                    error('Invalid variable name `[%s]`', ...
+                        strjoin(varName(isnan(idxs)), ', '));
+                end
+            end
+            var = obj.vars(idxs);
+        end
+        
+        function param = getParam(obj, paramName)
+            %GETPARAM Get a copy of a layer parameter
+            %   PARAM = GETPARAM(obj, NAME) returns a copy of the network parameter
+            %   with the specified NAME. NAME can also be a cell array
+            %   of strings or an array of indexes. If no parameter with a
+            %   specified name or index exists, an error is thrown.
+            %
+            %   See Also getParamIndex().
+            if isnumeric(paramName)
+                idxs = paramName;
+                if any(idxs > numel(obj.params) || idxs < 0)
+                    error('Invalid param indexes.');
+                end
+            else
+                assert(ischar(paramName), 'Param name must be string or number.');
+                idxs = obj.getParamIndex(paramName);
+                if any(isnan(idxs))
+                    error('Invalid param name `[%s]`', ...
+                        strjoin(paramName(isnan(idxs)), ', '));
+                end
+            end
+            param = obj.params(idxs);
+        end
+        
+        function order = getLayerExecutionOrder(obj)
+            %GETLAYEREXECUTIONORDER Get the order in which layers are evaluated
+            %   ORDER = GETLAYEREXECUTIONORDER(obj) returns a vector with
+            %   the indexes of the layers in the order in which they are
+            %   executed. This needs not to be the trivial order 1,2,...,L
+            %   as it depends on the graph topology.
+            order = obj.executionOrder ;
+        end
     end
-
-    function v = getVarIndex(obj, name)
-    %GETVARINDEX Get the index of a variable
-    %   INDEX = GETVARINDEX(obj, NAME) obtains the index of the variable
-    %   with the specified NAME. NAME can also be a cell array of
-    %   strings. If no variable with such a name is found, the value
-    %   NaN is returned for the index.
-    %
-    %   Variables can then be accessed as the `obj.vars(INDEX)`
-    %   property of the DaG.
-    %
-    %   Indexes are stable unless the DaG is modified (e.g. by adding
-    %   or removing layers); hence they can be cached for faster
-    %   variable access.
-    %
-    %   See Also getParamIndex(), getLayerIndex().
-      if iscell(name)
-        v = zeros(1, numel(name)) ;
-        for k = 1:numel(name)
-          v(k) = obj.getVarIndex(name{k}) ;
-        end
-      else
-        if isfield(obj.varNames, name)
-          v = obj.varNames.(name) ;
-        else
-          v = NaN ;
-        end
-      end
+    
+    methods (Static)
+        obj = fromSimpleNN(net, varargin)
+        obj = loadobj(s)
     end
-
-    function p = getParamIndex(obj, name)
-    %GETPARAMINDEX Get the index of a parameter
-    %   INDEX = GETPARAMINDEX(obj, NAME) obtains the index of the
-    %   parameter with the specified NAME. NAME can also be a cell
-    %   array of strings. If no parameter with such a name is found,
-    %   the value NaN is returned for the index.
-    %
-    %   Parameters can then be accessed as the `obj.params(INDEX)`
-    %   property of the DaG.
-    %
-    %   Indexes are stable unless the DaG is modified (e.g. by adding
-    %   or removing layers); hence they can be cached for faster
-    %   parameter access.
-    %
-    %   See Also getVarIndex(), getLayerIndex().
-      if iscell(name)
-        p = zeros(1, numel(name)) ;
-        for k = 1:numel(name)
-          p(k) = obj.getParamIndex(name{k}) ;
+    
+    methods (Access = {?dagnn.DagNN, ?dagnn.Layer})
+        function v = addVar(obj, name)
+            %ADDVAR  Add a variable to the DaG
+            %   V = ADDVAR(obj, NAME) adds a varialbe with the specified
+            %   NAME to the DaG. This is an internal function; variables
+            %   are automatically added when adding layers to the network.
+            v = obj.getVarIndex(name) ;
+            if ~isnan(v), return ; end
+            v = numel(obj.vars) + 1 ;
+            obj.vars(v) = struct(...
+                'name', {name}, ...
+                'value', {[]}, ...
+                'der', {[]}, ...
+                'fanin', {0}, ...
+                'fanout', {0}, ...
+                'precious', {false}) ;
+            obj.varNames.(name) = v ;
         end
-      else
-        if isfield(obj.paramNames, name)
-          p = obj.paramNames.(name) ;
-        else
-          p = NaN ;
+        
+        function p = addParam(obj, name)
+            %ADDPARAM  Add a parameter to the DaG
+            %   V = ADDPARAM(obj, NAME) adds a parameter with the specified NAME
+            %   to the DaG. This is an internal function; parameters are
+            %   automatically added when adding layers to the network.
+            p = obj.getParamIndex(name) ;
+            if ~isnan(p), return ; end
+            p = numel(obj.params) + 1 ;
+            obj.params(p) = struct(...
+                'name', {name}, ...
+                'value', {[]}, ...
+                'der', {[]}, ...
+                'fanout', {0}, ...
+                'trainMethod', {'gradient'}, ...
+                'learningRate', {1}, ...
+                'weightDecay', {1}) ;
+            obj.paramNames.(name) = p ;
         end
-      end
+        
+        function s=addSubNet(obj,SubNet)
+            s=obj.getSubNetIndex(SubNet.name);
+            if ~isnan(s),return;end
+            s=numel(obj.SubNets)+1;
+            obj.SubNets{1,s}=SubNet;
+            obj.SubNetNames.(SubNet.name)=s;
+        end
+        
+        
+        
+        
+        
     end
-
-    function layer = getLayer(obj, layerName)
-    %GETLAYER Get a copy of a layer definition
-    %   LAYER = GETLAYER(obj, NAME) returns a copy of the layer definition
-    %   structure with the specified NAME. NAME can also be a cell array
-    %   of strings or an array of indexes. If no parameter with a
-    %   specified name or index exists, an error is thrown.
-    %
-    %   See Also getLayerIndex().
-      if isnumeric(layerName)
-        idxs = layerName;
-        if any(idxs > numel(obj.layers) || idxs < 0)
-          error('Invalid layer indexes.');
-        end
-      else
-        assert(ischar(layerName), 'Layer name must be string or number.');
-        idxs = obj.getLayerIndex(layerName);
-        if any(isnan(idxs))
-          error('Invalid layer name `[%s]`', ...
-            strjoin(layerName(isnan(idxs)), ', '));
-        end
-      end
-      layer = obj.layers(idxs);
-    end
-
-    function var = getVar(obj, varName)
-    %GETVAR Get a copy of a layer definition
-    %   VAR = GETVAR(obj, NAME) returns a copy of the network variable
-    %   with the specified NAME. NAME can also be a cell array
-    %   of strings or an array of indexes. If no variable with a
-    %   specified name or index exists, an error is thrown.
-    %
-    %   See Also getVarIndex().
-      if isnumeric(varName)
-        idxs = varName;
-        if any(idxs > numel(obj.vars) || idxs < 0)
-          error('Invalid var indexes.');
-        end
-      else
-        assert(ischar(varName), 'Variable name must be string or number.');
-        idxs = obj.getVarIndex(varName);
-        if any(isnan(idxs))
-          error('Invalid variable name `[%s]`', ...
-            strjoin(varName(isnan(idxs)), ', '));
-        end
-      end
-      var = obj.vars(idxs);
-    end
-
-    function param = getParam(obj, paramName)
-    %GETPARAM Get a copy of a layer parameter
-    %   PARAM = GETPARAM(obj, NAME) returns a copy of the network parameter
-    %   with the specified NAME. NAME can also be a cell array
-    %   of strings or an array of indexes. If no parameter with a
-    %   specified name or index exists, an error is thrown.
-    %
-    %   See Also getParamIndex().
-      if isnumeric(paramName)
-        idxs = paramName;
-        if any(idxs > numel(obj.params) || idxs < 0)
-          error('Invalid param indexes.');
-        end
-      else
-        assert(ischar(paramName), 'Param name must be string or number.');
-        idxs = obj.getParamIndex(paramName);
-        if any(isnan(idxs))
-          error('Invalid param name `[%s]`', ...
-            strjoin(paramName(isnan(idxs)), ', '));
-        end
-      end
-      param = obj.params(idxs);
-    end
-
-    function order = getLayerExecutionOrder(obj)
-    %GETLAYEREXECUTIONORDER Get the order in which layers are evaluated
-    %   ORDER = GETLAYEREXECUTIONORDER(obj) returns a vector with
-    %   the indexes of the layers in the order in which they are
-    %   executed. This needs not to be the trivial order 1,2,...,L
-    %   as it depends on the graph topology.
-      order = obj.executionOrder ;
-    end
-  end
-
-  methods (Static)
-    obj = fromSimpleNN(net, varargin)
-    obj = loadobj(s)
-  end
-
-  methods (Access = {?dagnn.DagNN, ?dagnn.Layer})
-    function v = addVar(obj, name)
-    %ADDVAR  Add a variable to the DaG
-    %   V = ADDVAR(obj, NAME) adds a varialbe with the specified
-    %   NAME to the DaG. This is an internal function; variables
-    %   are automatically added when adding layers to the network.
-      v = obj.getVarIndex(name) ;
-      if ~isnan(v), return ; end
-      v = numel(obj.vars) + 1 ;
-      obj.vars(v) = struct(...
-        'name', {name}, ...
-        'value', {[]}, ...
-        'der', {[]}, ...
-        'fanin', {0}, ...
-        'fanout', {0}, ...
-        'precious', {false}) ;
-      obj.varNames.(name) = v ;
-    end
-
-    function p = addParam(obj, name)
-    %ADDPARAM  Add a parameter to the DaG
-    %   V = ADDPARAM(obj, NAME) adds a parameter with the specified NAME
-    %   to the DaG. This is an internal function; parameters are
-    %   automatically added when adding layers to the network.
-      p = obj.getParamIndex(name) ;
-      if ~isnan(p), return ; end
-      p = numel(obj.params) + 1 ;
-      obj.params(p) = struct(...
-        'name', {name}, ...
-        'value', {[]}, ...
-        'der', {[]}, ...
-        'fanout', {0}, ...
-        'trainMethod', {'gradient'}, ...
-        'learningRate', {1}, ...
-        'weightDecay', {1}) ;
-      obj.paramNames.(name) = p ;
-    end
-  end
 end

--- a/matlab/+dagnn/@DagNN/getVarSizes.m
+++ b/matlab/+dagnn/@DagNN/getVarSizes.m
@@ -32,5 +32,7 @@ end
 for layer = obj.layers(obj.executionOrder)
   in = layer.inputIndexes ;
   out = layer.outputIndexes ;
-  sizes(out) = layer.block.getOutputSizes(sizes(in)) ;
+
+     sizes(out) = layer.block.getOutputSizes(sizes(in)) ;
+
 end

--- a/matlab/+dagnn/@DagNN/initParams.m
+++ b/matlab/+dagnn/@DagNN/initParams.m
@@ -10,6 +10,10 @@ function initParams(obj)
 % the terms of the BSD license (see the COPYING file).
 
 for l = 1:numel(obj.layers)
+    if isa(obj.layers(l).block,'dagnn.SubNet')
+        obj.layers(l).block.subnet.initParams();
+        continue
+    end
   p = obj.getParamIndex(obj.layers(l).params) ;
   params = obj.layers(l).block.initParams() ;
   switch obj.device
@@ -18,5 +22,6 @@ for l = 1:numel(obj.layers)
     case 'gpu'
       params = cellfun(@gpuArray, params, 'UniformOutput', false) ;
   end
+  %[obj.params(p).value] = deal(params{:}) ;
   [obj.params(p).value] = deal(params{:}) ;
 end

--- a/matlab/+dagnn/@DagNN/setParamsValue.m
+++ b/matlab/+dagnn/@DagNN/setParamsValue.m
@@ -1,0 +1,33 @@
+function setParamsValue(obj,params,value)
+% INITPARAM  Initialize the paramers of the DagNN
+%   OBJ.INITPARAM() uses the INIT() method of each layer to initialize
+%   the corresponding parameters (usually randomly).
+
+% Copyright (C) 2015 Karel Lenc and Andrea Vedaldi.
+% All rights reserved.
+%
+% This file is part of the VLFeat library and is made available under
+% the terms of the BSD license (see the COPYING file).
+if ~iscell(params)
+    params={params};
+end
+% the terms of the BSD license (see the COPYING file).
+if ~iscell(value)
+    value={value};
+end
+p = obj.getParamIndex(params) ;
+
+for i=length(p)
+    if size(obj.params(p(i)).value)~=size(value{i})
+        error(['Param' params{i} 'has not been initialled or The size of updating value is wrong.'])
+    end
+end
+switch obj.device
+    case 'cpu'
+        value = cellfun(@gather, value, 'UniformOutput', false) ;
+    case 'gpu'
+        value = cellfun(@gpuArray, value, 'UniformOutput', false) ;
+end
+
+
+[obj.params(p).value] = deal(value{:}) ;

--- a/matlab/+dagnn/Conv.m
+++ b/matlab/+dagnn/Conv.m
@@ -41,7 +41,7 @@ classdef Conv < dagnn.Filter
       end
     end
 
-    function set.size(obj, ksize)
+    function set_size(obj, ksize)
       % make sure that ksize has 4 dimensions
       ksize = [ksize(:)' 1 1 1 1] ;
       obj.size = ksize(1:4) ;
@@ -54,6 +54,7 @@ classdef Conv < dagnn.Filter
       obj.size = obj.size ;
       obj.stride = obj.stride ;
       obj.pad = obj.pad ;
+      obj.hasBias= obj.hasBias;
     end
   end
 end

--- a/matlab/+dagnn/Layer.m
+++ b/matlab/+dagnn/Layer.m
@@ -99,7 +99,7 @@ classdef Layer < handle
       net = obj.net ;
 
       inputs = {net.vars(in).value} ;
-      derOutputs = {net.vars(out).der} ;
+      derOutputs = {net.vars(out).der} ; 
       for i = 1:numel(derOutputs)
         if isempty(derOutputs{i}), return ; end
       end
@@ -217,6 +217,9 @@ classdef Layer < handle
       for param = net.layers(index).params
         net.addParam(char(param)) ;
         p = net.getParamIndex(char(param)) ;
+      end
+      if isa(obj,'dagnn.SubNet')
+          net.addSubNet(obj);
       end
     end
 

--- a/matlab/+dagnn/SubNet.m
+++ b/matlab/+dagnn/SubNet.m
@@ -1,0 +1,66 @@
+classdef SubNet < dagnn.Layer
+    %building...
+    properties
+        inputs={};%input vars' name in subnet
+        outputs={};%output vars' name in subnet
+        subnet=dagnn.DagNN();
+        name='';
+    end
+    
+    methods
+        function outputs = forward(obj, inputs,params)
+            %`inputs`\`outputs` is a cell array of the type `{Value1,
+            %Value2, Value3,  ...}`, corresponding to the vars in subnet & parentnet
+            in=cell(1,length(inputs)*2);
+            for i=1:length(inputs)
+                in{i*2-1}=obj.inputs{i};
+                in{i*2}=inputs{i};
+            end
+            inputs=in;
+            obj.subnet.eval(inputs);
+            outputs=obj.subnet.getVar(obj.outputs);
+        end
+        
+        function [derInputs, derParams] = backward(obj, inputs, ~, derOutputs)
+            obj.subnet.eval(inputs,derOutputs);
+            v=obj.subnet.getVarIndex(obj.inputs);
+            derInputs=obj.subnet.vars(v).der;
+            derParams={};
+        end
+        
+        
+        function outputSizes = getOutputSizes(obj, inputSizes)
+            inVars=obj.inputs;
+            outVars=obj.outputs;
+            if numel(inVars)~=numel(inputSizes)
+                error('The numbers of input vars don''t match! ')
+            end
+            sizes=cell(1,2*numel(inVars));
+            for i=1:numel(inVars)
+                sizes(i*2-1)=inVars(i);
+                sizes(i*2)=inputSizes(i);
+            end
+            varsizes = obj.subnet.getVarSizes( sizes);
+                v=obj.subnet.getVarIndex(outVars) ;
+                outputSizes=varsizes(v);
+  
+        end
+        
+        
+        
+        function obj = SubNet(varargin)
+            obj.load(varargin);
+%             for i=1:length(obj.subnet.params)
+%                 if isempty(obj.subnet.params(i).value)
+%                     error('The params'' value of the subnet is empty! You should set or initial the value!')
+%                 end
+%             end
+            if ~iscell(obj.inputs)
+                obj.inputs={obj.inputs};
+            end
+            if ~iscell(obj.outputs)
+                obj.outputs={obj.outputs};
+            end
+        end
+    end
+end


### PR DESCRIPTION
Add a new block class named 'SubNet', which can wrap a determined net and work as new kind of filter.
This change can help achieve 'network in network', make it easier to construct a  new network based on constructed network, and offer more convenient solutions to construct a complex network .
